### PR TITLE
Fix USL test application compile error

### DIFF
--- a/usl/usl_test.c
+++ b/usl/usl_test.c
@@ -23,6 +23,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 
 #include "usl_list.h"
 
@@ -165,4 +166,6 @@ int main(int argc, char **argv)
 		result = test->func(test->arg);
 		printf("TEST: %s: %s\n", test->name, result == 0 ? "PASS" : "FAIL");
 	}
+
+	return 0;
 }


### PR DESCRIPTION
When I try to understand USL API, I compiled USL test application but failed due to missing a header file and missing return value in main() function. I added those to code and create a pull request for new comer. Hope openl2tp team can merge this commit.

Thanks and regards,
Xiangyu Chen